### PR TITLE
`install` takes the old version, not the version being installed

### DIFF
--- a/lib/ash_uuid/postgres_extension.ex
+++ b/lib/ash_uuid/postgres_extension.ex
@@ -4,7 +4,7 @@ defmodule AshUUID.PostgresExtension do
   use AshPostgres.CustomExtension, name: "ash-uuid", latest_version: 1
 
   @impl true
-  def install(1) do
+  def install(0) do
     """
     execute(\"\"\"
     CREATE OR REPLACE FUNCTION uuid_generate_v7()


### PR DESCRIPTION
We fixed a bug in `ash_postgres` where it was doing the wrong thing here, so it makes sense that this broke, but the solution is to fix downstream extensions.