### PR TITLE
Ash.Type.generator/1 should return DataStream

### DIFF
--- a/lib/ash_uuid/macros.ex
+++ b/lib/ash_uuid/macros.ex
@@ -24,7 +24,7 @@ defmodule AshUUID.Macros do
 
     default =
       quote do
-        fn -> AshUUID.UUID.generator(unquote(constraints)) end
+        fn -> AshUUID.UUID.generate(unquote(constraints)) end
       end
 
     field_opts =
@@ -77,7 +77,7 @@ defmodule AshUUID.Macros do
 
     default =
       quote do
-        fn -> AshUUID.UUID.generator(unquote(constraints)) end
+        fn -> AshUUID.UUID.generate(unquote(constraints)) end
       end
 
     argument_opts =

--- a/lib/ash_uuid/uuid.ex
+++ b/lib/ash_uuid/uuid.ex
@@ -23,8 +23,12 @@ defmodule AshUUID.UUID do
 
   @impl true
   def generator(constraints) do
+    StreamData.repeatedly(fn -> generate(constraints) end)
+  end
+
+  def generate(constraints) do
     {:ok, term} =
-      generate(constraints[:version])
+      generate_uuid(constraints[:version])
       |> process(
         constraints[:prefix],
         constraints[:strict?],
@@ -106,9 +110,9 @@ defmodule AshUUID.UUID do
 
   ###
 
-  defp generate(version)
-  defp generate(4), do: Uniq.UUID.uuid4()
-  defp generate(7), do: Uniq.UUID.uuid7()
+  defp generate_uuid(version)
+  defp generate_uuid(4), do: Uniq.UUID.uuid4()
+  defp generate_uuid(7), do: Uniq.UUID.uuid7()
 
   ###
 

--- a/test/ash_uuid/uuid_test.exs
+++ b/test/ash_uuid/uuid_test.exs
@@ -48,7 +48,7 @@ defmodule AshUUID.UUIDTest do
 
       assert {:ok, ^integer_uuid} = Ash.Type.apply_constraints(AshUUID.UUID, integer_uuid, constraints)
 
-      generated_uuid = Ash.Type.generator(AshUUID.UUID, constraints)
+      generated_uuid = AshUUID.UUID.generate(constraints)
       assert :raw = AshUUID.identify_format(generated_uuid)
       assert is_binary(generated_uuid)
       assert [generated_uuid_raw] = String.split(generated_uuid, "_")
@@ -87,7 +87,7 @@ defmodule AshUUID.UUIDTest do
 
       assert {:ok, ^integer_uuid} = Ash.Type.apply_constraints(AshUUID.UUID, integer_uuid, constraints)
 
-      generated_uuid = Ash.Type.generator(AshUUID.UUID, constraints)
+      generated_uuid = AshUUID.UUID.generate(constraints)
       assert :raw = AshUUID.identify_format(generated_uuid)
       assert is_binary(generated_uuid)
       assert [generated_uuid_raw] = String.split(generated_uuid, "_")
@@ -126,7 +126,7 @@ defmodule AshUUID.UUIDTest do
 
       assert {:ok, ^integer_uuid} = Ash.Type.apply_constraints(AshUUID.UUID, integer_uuid, constraints)
 
-      generated_uuid = Ash.Type.generator(AshUUID.UUID, constraints)
+      generated_uuid = AshUUID.UUID.generate(constraints)
       assert :encoded = AshUUID.identify_format(generated_uuid)
       assert is_binary(generated_uuid)
       assert [generated_uuid_encoded] = String.split(generated_uuid, "_")
@@ -166,7 +166,7 @@ defmodule AshUUID.UUIDTest do
 
       assert {:ok, ^integer_uuid} = Ash.Type.apply_constraints(AshUUID.UUID, integer_uuid, constraints)
 
-      generated_uuid = Ash.Type.generator(AshUUID.UUID, constraints)
+      generated_uuid = AshUUID.UUID.generate(constraints)
       assert :encoded = AshUUID.identify_format(generated_uuid)
       assert is_binary(generated_uuid)
       assert [generated_uuid_encoded] = String.split(generated_uuid, "_")
@@ -206,7 +206,7 @@ defmodule AshUUID.UUIDTest do
 
       assert {:ok, ^integer_uuid} = Ash.Type.apply_constraints(AshUUID.UUID, integer_uuid, constraints)
 
-      generated_uuid = Ash.Type.generator(AshUUID.UUID, constraints)
+      generated_uuid = AshUUID.UUID.generate(constraints)
       assert :prefixed = AshUUID.identify_format(generated_uuid)
       assert is_binary(generated_uuid)
       assert [^prefix, generated_uuid_encoded] = String.split(generated_uuid, "_")
@@ -246,7 +246,7 @@ defmodule AshUUID.UUIDTest do
 
       assert {:ok, ^integer_uuid} = Ash.Type.apply_constraints(AshUUID.UUID, integer_uuid, constraints)
 
-      generated_uuid = Ash.Type.generator(AshUUID.UUID, constraints)
+      generated_uuid = AshUUID.UUID.generate(constraints)
       assert :prefixed = AshUUID.identify_format(generated_uuid)
       assert is_binary(generated_uuid)
       assert [^prefix, generated_uuid_encoded] = String.split(generated_uuid, "_")


### PR DESCRIPTION
While using `Ash.Generator.seed/1` I got the following error:

```
** (ArgumentError) expected a generator, which can be a %StreamData{} struct, an atom, or a tuple with generators in it, but got:

  "col_02wsdmCe7p61fA5nVLcFYJ"

If you want to use a term as a "constant" generator, wrap it in a call to StreamData.constant/1 instead.
```

I noticed that the callback `Ash.Type.generator/1` should actually return an Enumerable instead of a single value:

```
@callback generator(constraints) :: Enumerable.t()
```

To fix the issue, I renamed the existing `generator/1` to `generate/1` and implemented the generator as expected (using [`Ash.Type.UUID`](https://github.com/ash-project/ash/blob/d13f2eca4730c150905954f32f73a10f9407efb2/lib/ash/type/uuid.ex#L13-L16) as reference).

**Heads-up:** I also tried to add a test for the generator function by using `Ash.Generator.seed!/1` in the existing tests (which failed, possibly because of an unrelated Ash bug). When I updated all the dependencies, I noticed that `ash_postgres` [v2.0.10](https://github.com/ash-project/ash_postgres/blob/main/CHANGELOG.md#v2010-2024-06-18) will break your tests (v2.0.9 is fine):

```
  6) test AshUUID.PrefixedV4 testing oranges (AshUUIDTest)
     test/ash_uuid_test.exs:140
     ** (Ash.Error.Unknown) Unknown Error

     * ** (Postgrex.Error) ERROR 22P02 (invalid_text_representation) invalid input syntax for type uuid: "orange-smoothie_3ZhwNimx2NuodIDMu2xmwo". If you are trying to query a JSON field, the parameter may need to be interpolated. Instead of

         p.json["field"] != "value"

     do

         p.json["field"] != ^"value"


         query: SELECT o0."id", o0."inserted_at", o0."orange_smoothie_id" FROM "oranges" AS o0 WHERE (o0."orange_smoothie_id"::uuid IN ('orange-smoothie_3ZhwNimx2NuodIDMu2xmwo'))
         at oranges
       (ecto_sql 3.11.3) lib/ecto/adapters/sql.ex:1054: Ecto.Adapters.SQL.raise_sql_call_error/1
       (ecto_sql 3.11.3) lib/ecto/adapters/sql.ex:952: Ecto.Adapters.SQL.execute/6
       (ecto 3.11.2) lib/ecto/repo/queryable.ex:232: Ecto.Repo.Queryable.execute/4
       (ecto 3.11.2) lib/ecto/repo/queryable.ex:19: Ecto.Repo.Queryable.all/3
       (ash_postgres 2.0.10) lib/data_layer.ex:758: anonymous fn/3 in AshPostgres.DataLayer.run_query/2
       (ash_postgres 2.0.10) lib/data_layer.ex:756: AshPostgres.DataLayer.run_query/2
       (ash 3.0.15) lib/ash/actions/read/read.ex:2423: Ash.Actions.Read.run_query/4
       (ash 3.0.15) lib/ash/actions/read/read.ex:447: anonymous fn/5 in Ash.Actions.Read.do_read/4
       (ash 3.0.15) lib/ash/actions/read/read.ex:777: Ash.Actions.Read.maybe_in_transaction/3
       (ash 3.0.15) lib/ash/actions/read/read.ex:248: Ash.Actions.Read.do_run/3
       (ash 3.0.15) lib/ash/actions/read/read.ex:66: anonymous fn/3 in Ash.Actions.Read.run/3
```