### PR TITLE
Add graphql_type for ash_graphql

### DIFF
--- a/lib/ash_uuid/uuid.ex
+++ b/lib/ash_uuid/uuid.ex
@@ -182,4 +182,6 @@ defmodule AshUUID.UUID do
   end
 
   defp dump(term, _initial_format, _requested_format), do: {:ok, term}
+
+  def graphql_type(_), do: :id
 end


### PR DESCRIPTION
Adds a missing `graphql_type/1` function definition for https://hexdocs.pm/ash_graphql/AshGraphql.Type.html#c:graphql_type/1, as ash_graphql errors out here for AshUUID.UUID attributes: https://github.com/ash-project/ash_graphql/blob/main/lib/resource/resource.ex#L4302

Please feel free to close this if you'd prefer another solution!