### PR TITLE
Allows newer version for ash and ash_postgres

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -43,8 +43,8 @@ defmodule AshUUID.MixProject do
   defp deps do
     [
       {:uniq, "~> 0.6"},
-      {:ash, "~> 3.0.0"},
-      {:ash_postgres, "~> 2.0.11"},
+      {:ash, "~> 3.0"},
+      {:ash_postgres, "~> 2.0 and >= 2.0.11"},
       # Testing, documentation, and release tools
       {:mix_test_interactive, ">= 0.0.0", only: :test, runtime: false},
       {:mix_audit, ">= 0.0.0", only: [:dev, :test], runtime: false},


### PR DESCRIPTION
This PR allows `ash_uuid` to support newer versions of its dependencies.

Currently, `:ash` is restricted to versions below `3.1.x`, and `:ash_postgres` is restricted to versions below `2.1.x`. These constraints were introduced in #9 and #11 (for `:ash_postgres` specifically), which is why an additional version condition was added for `:ash_postgres`.

These restrictions are now causing issues because the pinned version (2.0.11) is flagged as insecure.